### PR TITLE
Add Covid and Omnicron autoreact emoji

### DIFF
--- a/cogs/autoreacts.py
+++ b/cogs/autoreacts.py
@@ -94,7 +94,7 @@ class AutoReact(commands.Cog):
                 yuried = self.bot.get_emoji(760297062104301570)
                 if yuried is not None:
                     await message.add_reaction(yuried)
-            if word == "covid" or word == "omnicron":
+            if word == "covid" or word == "omnicron" or word == "omicron":
                 megatron = self.bot.get_emoji(930950428965871658)
                 if megatron is not None:
                     await message.add_reaction(megatron)

--- a/cogs/autoreacts.py
+++ b/cogs/autoreacts.py
@@ -94,6 +94,10 @@ class AutoReact(commands.Cog):
                 yuried = self.bot.get_emoji(760297062104301570)
                 if yuried is not None:
                     await message.add_reaction(yuried)
+            if word == "covid" or word == "omnicron":
+                megatron = self.bot.get_emoji(930950428965871658)
+                if megatron is not None:
+                    await message.add_reaction(megatron)
 
 
 def setup(bot):


### PR DESCRIPTION
This PR adds an auto-react to the OC discord bot for the words "omnicron" and "covid".
The emoji used is of the :megatron: emoji, custom added to the OC discord.

![image](https://user-images.githubusercontent.com/15949137/149235101-d135b6e6-77db-4e6a-851f-fa375bf120f5.png)
